### PR TITLE
Accepting null as result for BuildStatus

### DIFF
--- a/app/jsonhandling/BuildStatus.java
+++ b/app/jsonhandling/BuildStatus.java
@@ -2,7 +2,7 @@ package jsonhandling;
 
 public enum BuildStatus
 {
-	STABLE("SUCCESS"), UNSTABLE("UNSTABLE"), FAILED("FAILURE"), ABORTED("ABORTED");
+	STABLE("SUCCESS"), UNSTABLE("UNSTABLE"), FAILED("FAILURE"), ABORTED("ABORTED"), NULL("NULL");
 
 	private String jenkinsStatus;
 
@@ -18,14 +18,11 @@ public enum BuildStatus
 
 	public static BuildStatus fromString(final String text)
 	{
-		if (text != null)
+		for (BuildStatus status : BuildStatus.values())
 		{
-			for (BuildStatus status : BuildStatus.values())
+			if (text.equalsIgnoreCase(status.jenkinsStatus))
 			{
-				if (text.equalsIgnoreCase(status.jenkinsStatus))
-				{
-					return status;
-				}
+				return status;
 			}
 		}
 		throw new IllegalStateException(String.format("'%s' is not a valid build status", text));


### PR DESCRIPTION
As that is apparently required (analysis failed on this) with the following exception: 

``` java
Error during scheduled task
java.lang.RuntimeException: java.lang.IllegalStateException: 'null' is not a valid build status
    at play.db.jpa.JPA.withTransaction(JPA.java:108) ~[com.typesafe.play.play-java-jpa_2.10-2.2.1.jar:2.2.1]
    at Global$1.run(Global.java:29) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:na]
    at akka.actor.LightArrayRevolverScheduler$$anon$3$$anon$2.run(Scheduler.scala:241) [com.typesafe.akka.akka-actor_2.10-2.2.0.jar:2.2.0]
    at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:42) [com.typesafe.akka.akka-actor_2.10-2.2.0.jar:2.2.0]
    at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:386) [com.typesafe.akka.akka-actor_2.10-2.2.0.jar:2.2.0]
    at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260) [org.scala-lang.scala-library-2.10.2.jar:na]
    at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339) [org.scala-lang.scala-library-2.10.2.jar:na]
    at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979) [org.scala-lang.scala-library-2.10.2.jar:na]
    at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107) [org.scala-lang.scala-library-2.10.2.jar:na]
Caused by: java.lang.IllegalStateException: 'null' is not a valid build status
    at jsonhandling.BuildStatus.fromString(BuildStatus.java:31) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at jsonhandling.RunParser.getStatus(RunParser.java:15) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.analyzers.RunAnalyzer.analyze(RunAnalyzer.java:40) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.analyzers.JobAnalyzer.analyzeDetails(JobAnalyzer.java:96) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.analyzers.JobAnalyzer.analyze(JobAnalyzer.java:55) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.analyzers.ViewAnalyzer.analyze(ViewAnalyzer.java:58) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.analyzers.JenkinsServerAnalyzer.analyzeViews(JenkinsServerAnalyzer.java:71) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.executor.AnalysisExecutor.analyzeServer(AnalysisExecutor.java:102) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at analysis.executor.AnalysisExecutor.executeAnalysis(AnalysisExecutor.java:71) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
    at Global$1$1.invoke(Global.java:34) ~[analysisdashboard.analysisdashboard-1.0-SNAPSHOT.jar:na]
    at play.db.jpa.JPA$1.apply(JPA.java:103) ~[com.typesafe.play.play-java-jpa_2.10-2.2.1.jar:2.2.1]
    at play.db.jpa.JPA$1.apply(JPA.java:101) ~[com.typesafe.play.play-java-jpa_2.10-2.2.1.jar:2.2.1]
    at play.db.jpa.JPA.withTransaction(JPA.java:132) ~[com.typesafe.play.play-java-jpa_2.10-2.2.1.jar:2.2.1]
    at play.db.jpa.JPA.withTransaction(JPA.java:101) ~[com.typesafe.play.play-java-jpa_2.10-2.2.1.jar:2.2.1]
    ... 8 common frames omitted
```
